### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "MIT"
 description = "A lightweight, easy-to-read config format with clean section syntax and simple parsing."
 readme = "README.md"
-repository = "https://www.github.com/smit4k/lqf"
+repository = "https://github.com/smit4k/lqf"
 
 [dependencies]
 clap = { version = "4.5.39", features = ["derive"] }


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96

You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/smit4k